### PR TITLE
feat(npm): turn repo into npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export { SNECTVaultAdapter } from "./vaults/beraborrow/sNECTVaultAdapter";


### PR DESCRIPTION
This PR adds an `index.ts` file for module exports so it can be turned into a importable `npm` module. Anyone importing this package can use it with:
```typescript
import { WberaLBGTVaultAdapter } from "berachain-hub-pol-adapters";

const tokens = await adapter.getIncentiveTokens();
```

This PR also adds files in`/dist` to `.gitignore`, since that directory contains all build outputs of the TypeScript compiler (`tsc`) and not the source. We will build in CI/CD prior to publishing a new version of the package.