### PR TITLE
feat(types): add chainId to TokenPrice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@berachain/hub-pol-adapters",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Token price discovery adapters for Berachain Hub PoL",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export interface TokenPrice {
   address: string;
   price: number;
   timestamp: number;
+  chainId: number;
 }
 
 /**

--- a/src/vaults/beraborrow/sNECTVaultAdapter.ts
+++ b/src/vaults/beraborrow/sNECTVaultAdapter.ts
@@ -85,6 +85,7 @@ export class SNECTVaultAdapter extends BaseAdapter {
           address: token.address,
           price: Number(price) / 1e18, // Convert from bigint to number and adjust decimals
           timestamp: Date.now(),
+          chainId: token.chainId,
         };
       })
     );

--- a/src/vaults/examples/wbera-lbgt-vault-adapter.ts
+++ b/src/vaults/examples/wbera-lbgt-vault-adapter.ts
@@ -35,6 +35,7 @@ export class WberaLBGTVaultAdapter extends BaseAdapter {
         Number(pool.dynamicData.totalLiquidity) /
         Number(pool.dynamicData.totalShares),
       timestamp: Date.now(),
+      chainId: 80094,
     }));
   }
 
@@ -60,6 +61,7 @@ export class WberaLBGTVaultAdapter extends BaseAdapter {
       address: tokenPrice.address,
       price: tokenPrice.price,
       timestamp: tokenPrice.updatedAt,
+      chainId: 80094,
     }));
   }
 }


### PR DESCRIPTION
This PR backfills a new field `chainId` into the `TokenPrice` type. It also bumps the package version to `1.1.0`.