### PR TITLE
feat(repo): add github actions scripts for ci/cd

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,24 @@
+name: build
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    name: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - name: Install dependencies
+        run: npm install
+      - name: Run build
+        run: npm run build
+      # - name: Run tests
+      #   run: npm run test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,24 +1,24 @@
 name: build
 on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+    pull_request:
+        branches:
+            - main
+    push:
+        branches:
+            - main
 jobs:
-  format:
-    runs-on: ubuntu-latest
-    name: build
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
-      - name: Install dependencies
-        run: npm install
-      - name: Run build
-        run: npm run build
-      # - name: Run tests
-      #   run: npm run test
+    format:
+        runs-on: ubuntu-latest
+        name: build
+        steps:
+            - uses: actions/checkout@v4
+            - name: Setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: latest
+            - name: Install dependencies
+              run: npm install
+            - name: Run build
+              run: npm run build
+            # - name: Run tests
+            #   run: npm run test

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,22 @@
+name: format
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    name: Prettier
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - name: Install dev dependencies
+        run: npm install --only=dev
+      - name: Run Prettier
+        run: npx prettier --check .

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,22 +1,22 @@
 name: format
 on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+    pull_request:
+        branches:
+            - main
+    push:
+        branches:
+            - main
 jobs:
-  format:
-    runs-on: ubuntu-latest
-    name: Prettier
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
-      - name: Install dev dependencies
-        run: npm install --only=dev
-      - name: Run Prettier
-        run: npx prettier --check .
+    format:
+        runs-on: ubuntu-latest
+        name: Prettier
+        steps:
+            - uses: actions/checkout@v4
+            - name: Setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: latest
+            - name: Install dev dependencies
+              run: npm install --only=dev
+            - name: Run Prettier
+              run: npx prettier --check .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,22 +1,22 @@
 name: lint
 on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+    pull_request:
+        branches:
+            - main
+    push:
+        branches:
+            - main
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    name: ESLint
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
-      - name: Install dev dependencies
-        run: npm install --only=dev
-      - name: Run ESLint
-        run: npx eslint .
+    lint:
+        runs-on: ubuntu-latest
+        name: ESLint
+        steps:
+            - uses: actions/checkout@v4
+            - name: Setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: latest
+            - name: Install dev dependencies
+              run: npm install --only=dev
+            - name: Run ESLint
+              run: npx eslint .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,22 @@
+name: lint
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: ESLint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - name: Install dev dependencies
+        run: npm install --only=dev
+      - name: Run ESLint
+        run: npx eslint .

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,48 +1,48 @@
 name: Publish Package to npm
 
 on:
-  release:
-    types: [published]
+    release:
+        types: [published]
 
 permissions:
-  contents: write
+    contents: write
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GHCR_REGISTRY }}
-          ref: ${{ github.event.repository.default_branch }}
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
-          registry-url: "https://registry.npmjs.org"
-      - name: Install dependencies
-        run: npm ci
-      - name: Run build
-        run: npm run build
-      - name: Run tests
-        run: npm run test
-      - name: Update package.json with release tag
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          echo "Updating package.json version to $TAG"
-          npm version "$TAG" --no-git-tag-version
-      - name: Commit and push version update
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add package.json package-lock.json
-          git commit -m "Update package.json to version $TAG"
-          git push origin ${{ github.event.repository.default_branch }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHCR_REGISTRY }}
-      - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.GHCR_REGISTRY }}
+                  ref: ${{ github.event.repository.default_branch }}
+            - name: Setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: latest
+                  registry-url: "https://registry.npmjs.org"
+            - name: Install dependencies
+              run: npm ci
+            - name: Run build
+              run: npm run build
+            - name: Run tests
+              run: npm run test
+            - name: Update package.json with release tag
+              run: |
+                  TAG="${{ github.event.release.tag_name }}"
+                  echo "Updating package.json version to $TAG"
+                  npm version "$TAG" --no-git-tag-version
+            - name: Commit and push version update
+              run: |
+                  TAG="${{ github.event.release.tag_name }}"
+                  git config user.name "github-actions"
+                  git config user.email "github-actions@github.com"
+                  git add package.json package-lock.json
+                  git commit -m "Update package.json to version $TAG"
+                  git push origin ${{ github.event.repository.default_branch }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GHCR_REGISTRY }}
+            - name: Publish to npm
+              run: npm publish --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,48 @@
+name: Publish Package to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GHCR_REGISTRY }}
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run build
+        run: npm run build
+      - name: Run tests
+        run: npm run test
+      - name: Update package.json with release tag
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "Updating package.json version to $TAG"
+          npm version "$TAG" --no-git-tag-version
+      - name: Commit and push version update
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add package.json package-lock.json
+          git commit -m "Update package.json to version $TAG"
+          git push origin ${{ github.event.repository.default_branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHCR_REGISTRY }}
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**PR #9 must be merged and this branch rebased before merging** 

This PR adds GitHub Actions scripts for CI/CD - linting, formatting, building, testing, and publishing to the `npm` registry. Testing is disabled (commented-out) until automated run functionality is added. 

Formatting, linting, building and testing is triggered on every merge to the `main` branch, and any PRs to the `main` branch. Publishing to `npm` is only done when a new release is published. It requires an auth token that can be retrieved from the `npm` website.