### PR TITLE
chore(gitinore): ignore yarn.lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+yarn.lock


### PR DESCRIPTION
This PR adds `yarn.lock` files to `.gitignore` so it doesn't get merged into this repo. Users can use yarn locally if they choose to, but we officially support `npm`.