### PR TITLE
refactor: publicClient as property, single array of exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,9 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.8.4",
-        "ethers": "^6.13.5",
         "graphql": "^16.10.0",
         "graphql-request": "^7.1.2",
-        "viem": "^2.25.0"
+        "viem": "2.41.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.24.0",
@@ -35,12 +33,6 @@
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.29.1"
       }
-    },
-    "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -1813,25 +1805,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1876,35 +1856,35 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
-      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
-      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.8.1",
-        "@noble/hashes": "~1.7.1",
-        "@scure/base": "~1.2.2"
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1914,9 +1894,9 @@
       }
     },
     "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1926,22 +1906,22 @@
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
-      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.7.1",
-        "@scure/base": "~1.2.4"
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -2381,16 +2361,16 @@
       }
     },
     "node_modules/abitype": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.1.0.tgz",
+      "integrity": "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4",
-        "zod": "^3 >=3.22.0"
+        "zod": "^3.22.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2436,12 +2416,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -2549,23 +2523,6 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2786,19 +2743,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2965,18 +2909,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3099,15 +3031,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3162,20 +3085,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -3227,51 +3136,6 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -3567,43 +3431,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ethers": {
-      "version": "6.13.5",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
-      "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -3818,41 +3645,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3879,6 +3671,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3904,30 +3697,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3936,19 +3705,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -4049,18 +3805,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4106,37 +3850,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4335,9 +4053,9 @@
       "license": "ISC"
     },
     "node_modules/isows": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
-      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
       "funding": [
         {
           "type": "github",
@@ -5266,15 +4984,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -6110,27 +5819,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -6253,9 +5941,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
-      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.6.tgz",
+      "integrity": "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg==",
       "funding": [
         {
           "type": "github",
@@ -6264,12 +5952,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "^1.10.1",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/bip32": "^1.5.0",
-        "@scure/bip39": "^1.4.0",
-        "abitype": "^1.0.6",
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
         "eventemitter3": "5.0.1"
       },
       "peerDependencies": {
@@ -6281,13 +5970,19 @@
         }
       }
     },
+    "node_modules/ox/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
     "node_modules/ox/node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -6297,9 +5992,9 @@
       }
     },
     "node_modules/ox/node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -6585,12 +6280,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7157,12 +6846,6 @@
         }
       }
     },
-    "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
-    },
     "node_modules/tsx": {
       "version": "4.19.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
@@ -7242,12 +6925,6 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
     },
     "node_modules/unist-util-is": {
       "version": "6.0.0",
@@ -7372,9 +7049,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.25.0.tgz",
-      "integrity": "sha512-TtFgfQkZOfb642s8+i+h27dRhBfZV//WWOkZ9saoS1Ml8kipj9RiOiDaSmAUly1rhq9kbnYhni1xVtb195XVGA==",
+      "version": "2.41.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.41.2.tgz",
+      "integrity": "sha512-LYliajglBe1FU6+EH9mSWozp+gRA/QcHfxeD9Odf83AdH5fwUS7DroH4gHvlv6Sshqi1uXrYFA2B/EOczxd15g==",
       "funding": [
         {
           "type": "github",
@@ -7383,14 +7060,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "1.8.1",
-        "@noble/hashes": "1.7.1",
-        "@scure/bip32": "1.6.2",
-        "@scure/bip39": "1.5.4",
-        "abitype": "1.0.8",
-        "isows": "1.0.6",
-        "ox": "0.6.9",
-        "ws": "8.18.1"
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.1.0",
+        "isows": "1.0.7",
+        "ox": "0.9.6",
+        "ws": "8.18.3"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -7402,12 +7079,12 @@
       }
     },
     "node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -7417,9 +7094,9 @@
       }
     },
     "node_modules/viem/node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -7429,9 +7106,9 @@
       }
     },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -7529,6 +7206,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -13,11 +13,9 @@
   "author": "devs@berachain.com",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.8.4",
-    "ethers": "^6.13.5",
     "graphql": "^16.10.0",
     "graphql-request": "^7.1.2",
-    "viem": "^2.25.0"
+    "viem": "2.41.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",

--- a/src/common/viem.ts
+++ b/src/common/viem.ts
@@ -1,9 +1,0 @@
-import { createPublicClient, http } from "viem";
-import { berachain } from "viem/chains";
-
-export const publicClient = createPublicClient({
-    chain: berachain,
-    transport: http(),
-});
-
-export default publicClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,10 @@ import { WberaUsdcVaultAdapter } from "./vaults/brownfi/wberaUsdcVaultAdapter";
 import { WberaHoneyVaultAdapter } from "./vaults/brownfi/wberaHoneyVaultAdapter";
 import { WinnieSwapAdapter } from "./vaults/winnieswap/WinnieSwapAdapter";
 import { TermMaxVaultAdapter } from "./vaults/termmax";
+import { BaseAdapter } from "./types";
+import { WberaLBGTVaultAdapter } from "./vaults/examples/wbera-lbgt-vault-adapter";
 
-export {
+export const adapters: (typeof BaseAdapter)[] = [
     SNECTVaultAdapter,
     AquaBeraBeramoAdapter,
     AquaBeraHenloAdapter,
@@ -33,5 +35,6 @@ export {
     WberaUsdcVaultAdapter,
     WberaHoneyVaultAdapter,
     WinnieSwapAdapter,
+    WberaLBGTVaultAdapter,
     TermMaxVaultAdapter,
-};
+];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,6 @@
+import { http, createPublicClient, PublicClient } from "viem";
+import { berachain } from "viem/chains";
+
 export interface Token {
     address: string;
     symbol: string;
@@ -22,10 +25,24 @@ export abstract class BaseAdapter {
     description?: string;
     enabled: boolean;
 
-    constructor(config: { name: string; description?: string; enabled?: boolean }) {
+    protected publicClient: PublicClient;
+
+    constructor(config: {
+        name: string;
+        description?: string;
+        enabled?: boolean;
+        publicClient?: PublicClient;
+    }) {
         this.name = config.name;
         this.description = config.description;
         this.enabled = config.enabled ?? true;
+
+        this.publicClient =
+            config.publicClient ??
+            createPublicClient({
+                chain: berachain,
+                transport: http("https://rpc.berachain.com"),
+            });
     }
 
     /**

--- a/src/utils/adapter.test.ts
+++ b/src/utils/adapter.test.ts
@@ -1,6 +1,7 @@
 import { BaseAdapter, Token } from "../types";
 import path from "path";
 import fs from "fs";
+import { adapters as exportedAdapters } from "../index";
 
 async function main() {
     // Get the filename from command line arguments
@@ -23,6 +24,20 @@ async function main() {
         (file) => `../vaults/${file.split("src/vaults/").reverse()[0]}`
     );
     const loadAdapters = await loadAdapterClasses(adapterImportPaths);
+
+    if (runAll && loadAdapters.length !== exportedAdapters.length) {
+        // -1 for the BaseAdapter class
+
+        const missingAdapters = loadAdapters
+            .filter(
+                (adapter) => !exportedAdapters.some((eAdapter) => eAdapter.name === adapter.name)
+            )
+            .map((adapter) => adapter.name);
+        console.error(
+            `Expected ${exportedAdapters.length} adapters, but found ${loadAdapters.length}. Missing adapters: ${missingAdapters.join(", ")}`
+        );
+        process.exit(1);
+    }
 
     // Run the test with the provided classes
     run(loadAdapters);

--- a/src/vaults/aquabera/beramoWberaVaultAdapter.ts
+++ b/src/vaults/aquabera/beramoWberaVaultAdapter.ts
@@ -1,6 +1,4 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
 
 const BERACHAIN_API_URL = "https://api.berachain.com/graphql";
 
@@ -57,14 +55,9 @@ export class AquaBeraBeramoAdapter extends BaseAdapter {
      * These prices are used to calculate TVL for APR calculations
      */
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
-                const totalSupply = (await publicClient.readContract({
+                const totalSupply = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -78,7 +71,7 @@ export class AquaBeraBeramoAdapter extends BaseAdapter {
                     functionName: "totalSupply",
                 })) as bigint;
 
-                const [totalAmount0, totalAmount1] = (await publicClient.readContract({
+                const [totalAmount0, totalAmount1] = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -95,7 +88,7 @@ export class AquaBeraBeramoAdapter extends BaseAdapter {
                     functionName: "getTotalAmounts",
                 })) as [bigint, bigint];
 
-                const token0_addr = (await publicClient.readContract({
+                const token0_addr = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -109,7 +102,7 @@ export class AquaBeraBeramoAdapter extends BaseAdapter {
                     functionName: "token0",
                 })) as string;
 
-                const token1_addr = (await publicClient.readContract({
+                const token1_addr = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {

--- a/src/vaults/aquabera/henloWberaVaultAdapter.ts
+++ b/src/vaults/aquabera/henloWberaVaultAdapter.ts
@@ -1,6 +1,4 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
 
 const BERACHAIN_API_URL = "https://api.berachain.com/graphql";
 
@@ -57,14 +55,9 @@ export class AquaBeraHenloAdapter extends BaseAdapter {
      * These prices are used to calculate TVL for APR calculations
      */
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
-                const totalSupply = (await publicClient.readContract({
+                const totalSupply = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -78,7 +71,7 @@ export class AquaBeraHenloAdapter extends BaseAdapter {
                     functionName: "totalSupply",
                 })) as bigint;
 
-                const [totalAmount0, totalAmount1] = (await publicClient.readContract({
+                const [totalAmount0, totalAmount1] = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -95,7 +88,7 @@ export class AquaBeraHenloAdapter extends BaseAdapter {
                     functionName: "getTotalAmounts",
                 })) as [bigint, bigint];
 
-                const token0_addr = (await publicClient.readContract({
+                const token0_addr = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -109,7 +102,7 @@ export class AquaBeraHenloAdapter extends BaseAdapter {
                     functionName: "token0",
                 })) as string;
 
-                const token1_addr = (await publicClient.readContract({
+                const token1_addr = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {

--- a/src/vaults/bend/index.ts
+++ b/src/vaults/bend/index.ts
@@ -1,7 +1,6 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
 import { fetchTokenPrice } from "../examples/hub-api";
-import { berachain } from "viem/chains";
-import { createPublicClient, http, parseEther } from "viem";
+import { parseEther } from "viem";
 
 export class BendVaultAdapter extends BaseAdapter {
     constructor() {
@@ -35,16 +34,10 @@ export class BendVaultAdapter extends BaseAdapter {
      * These prices are used to calculate TVL for APR calculations
      */
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        // Create a public client directly in the function
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
                 // Perform individual calls to get the underlying asset, totalSupply and totalAssets
-                const ratio = await publicClient.readContract({
+                const ratio = await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     args: [parseEther("1")],
                     abi: [
@@ -59,7 +52,7 @@ export class BendVaultAdapter extends BaseAdapter {
                     functionName: "convertToAssets",
                 });
 
-                const underlyingAsset = await publicClient.readContract({
+                const underlyingAsset = await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {

--- a/src/vaults/beraborrow/sNECTVaultAdapter.ts
+++ b/src/vaults/beraborrow/sNECTVaultAdapter.ts
@@ -1,6 +1,4 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
 
 export class SNECTVaultAdapter extends BaseAdapter {
     constructor() {
@@ -35,16 +33,10 @@ export class SNECTVaultAdapter extends BaseAdapter {
      * These prices are used to calculate TVL for APR calculations
      */
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        // Creamos un cliente público directamente en la función
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
                 // Realizar llamadas individuales para obtener totalSupply y totalAssets
-                const totalSupply = (await publicClient.readContract({
+                const totalSupply = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -58,7 +50,7 @@ export class SNECTVaultAdapter extends BaseAdapter {
                     functionName: "totalSupply",
                 })) as bigint;
 
-                const totalAssets = (await publicClient.readContract({
+                const totalAssets = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {

--- a/src/vaults/brownfi/wberaHoneyVaultAdapter.ts
+++ b/src/vaults/brownfi/wberaHoneyVaultAdapter.ts
@@ -1,12 +1,5 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
 import { fetchTokenPrice } from "../examples/hub-api";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
-
-const publicClient = createPublicClient({
-    chain: berachain,
-    transport: http("https://rpc.berachain.com"),
-});
 
 export class WberaHoneyVaultAdapter extends BaseAdapter {
     constructor() {
@@ -33,7 +26,7 @@ export class WberaHoneyVaultAdapter extends BaseAdapter {
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
-                const totalSupply = (await publicClient.readContract({
+                const totalSupply = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -47,7 +40,7 @@ export class WberaHoneyVaultAdapter extends BaseAdapter {
                     functionName: "totalSupply",
                 })) as bigint;
 
-                const token0_addr = (await publicClient.readContract({
+                const token0_addr = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -61,7 +54,7 @@ export class WberaHoneyVaultAdapter extends BaseAdapter {
                     functionName: "token0",
                 })) as string;
 
-                const token1_addr = (await publicClient.readContract({
+                const token1_addr = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -115,7 +108,7 @@ export class WberaHoneyVaultAdapter extends BaseAdapter {
 
         const balances: bigint[] = [];
         for (const token of tokens) {
-            const balance = (await publicClient.readContract({
+            const balance = (await this.publicClient.readContract({
                 address: token as `0x${string}`,
                 abi: [
                     {

--- a/src/vaults/brownfi/wberaUsdcVaultAdapter.ts
+++ b/src/vaults/brownfi/wberaUsdcVaultAdapter.ts
@@ -1,12 +1,5 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
 import { fetchTokenPrice } from "../examples/hub-api";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
-
-const publicClient = createPublicClient({
-    chain: berachain,
-    transport: http("https://rpc.berachain.com"),
-});
 
 export class WberaUsdcVaultAdapter extends BaseAdapter {
     constructor() {
@@ -33,7 +26,7 @@ export class WberaUsdcVaultAdapter extends BaseAdapter {
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
-                const totalSupply = (await publicClient.readContract({
+                const totalSupply = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -47,7 +40,7 @@ export class WberaUsdcVaultAdapter extends BaseAdapter {
                     functionName: "totalSupply",
                 })) as bigint;
 
-                const token0_addr = (await publicClient.readContract({
+                const token0_addr = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -61,7 +54,7 @@ export class WberaUsdcVaultAdapter extends BaseAdapter {
                     functionName: "token0",
                 })) as string;
 
-                const token1_addr = (await publicClient.readContract({
+                const token1_addr = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -115,7 +108,7 @@ export class WberaUsdcVaultAdapter extends BaseAdapter {
 
         const balances: bigint[] = [];
         for (const token of tokens) {
-            const balance = (await publicClient.readContract({
+            const balance = (await this.publicClient.readContract({
                 address: token as `0x${string}`,
                 abi: [
                     {

--- a/src/vaults/bullish/BullIshGaugeAdapter.ts
+++ b/src/vaults/bullish/BullIshGaugeAdapter.ts
@@ -1,6 +1,4 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
 import { fetchTokenPrice } from "../examples/hub-api";
 
 export class BullIshGaugeAdapter extends BaseAdapter {
@@ -25,11 +23,6 @@ export class BullIshGaugeAdapter extends BaseAdapter {
     }
 
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         // Get BERA price
         const beraPrices = await fetchTokenPrice(["0x6969696969696969696969696969696969696969"]);
         const beraPrice =
@@ -41,7 +34,7 @@ export class BullIshGaugeAdapter extends BaseAdapter {
 
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
-                const _totalSupply = (await publicClient.readContract({
+                const _totalSupply = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {

--- a/src/vaults/concrete/concreteVaultsAdapter.ts
+++ b/src/vaults/concrete/concreteVaultsAdapter.ts
@@ -1,6 +1,4 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
-import { createPublicClient, http } from "viem";
-import { berachain } from "viem/chains";
 
 interface ConcreteVault {
     vaultAddress: `0x${string}`;
@@ -279,11 +277,6 @@ export class ConcreteVaultAdapter extends BaseAdapter {
     }
 
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         return Promise.all(
             stakingTokens.map(async (token) => {
                 const vault = concreteVaults.find(
@@ -291,7 +284,7 @@ export class ConcreteVaultAdapter extends BaseAdapter {
                 );
                 if (!vault) throw new Error(`Vault not found for staking token ${token.address}`);
                 const { vaultAddress, funded } = vault;
-                const totalSupply = (await publicClient.readContract({
+                const totalSupply = (await this.publicClient.readContract({
                     address: vaultAddress,
                     abi: [
                         {
@@ -304,7 +297,7 @@ export class ConcreteVaultAdapter extends BaseAdapter {
                     ],
                     functionName: "totalSupply",
                 })) as bigint;
-                const totalAssets = (await publicClient.readContract({
+                const totalAssets = (await this.publicClient.readContract({
                     address: vaultAddress,
                     abi: [
                         {

--- a/src/vaults/dolomite/drusdVaultAdapter.ts
+++ b/src/vaults/dolomite/drusdVaultAdapter.ts
@@ -1,6 +1,4 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
 
 export class DRUSDVaultAdapter extends BaseAdapter {
     constructor() {
@@ -33,14 +31,9 @@ export class DRUSDVaultAdapter extends BaseAdapter {
      * These prices are used to calculate TVL for APR calculations
      */
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
-                const totalSupply = (await publicClient.readContract({
+                const totalSupply = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -54,7 +47,7 @@ export class DRUSDVaultAdapter extends BaseAdapter {
                     functionName: "totalSupply",
                 })) as bigint;
 
-                const totalAssets = (await publicClient.readContract({
+                const totalAssets = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {

--- a/src/vaults/ivx/ivx-adapter.ts
+++ b/src/vaults/ivx/ivx-adapter.ts
@@ -1,17 +1,10 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
 import { fetchTokenPrice } from "../examples/hub-api";
 
 interface SupportedToken {
     readonly address: string;
     readonly decimals: number;
 }
-
-const publicClient = createPublicClient({
-    chain: berachain,
-    transport: http("https://rpc.berachain.com"),
-});
 
 export class IVXVaultAdapter extends BaseAdapter {
     constructor() {
@@ -74,7 +67,7 @@ export class IVXVaultAdapter extends BaseAdapter {
             let TVL = 0;
             const IVLP = token.address as `0x${string}`;
             // Get Staked Token Total Supply
-            const totalSupply = (await publicClient.readContract({
+            const totalSupply = (await this.publicClient.readContract({
                 address: IVLP,
                 abi: [
                     {
@@ -133,7 +126,7 @@ export class IVXVaultAdapter extends BaseAdapter {
 
         const balances: bigint[] = [];
         for (const token of tokens) {
-            const balance = (await publicClient.readContract({
+            const balance = (await this.publicClient.readContract({
                 address: token as `0x${string}`,
                 abi: [
                     {

--- a/src/vaults/termmax/index.ts
+++ b/src/vaults/termmax/index.ts
@@ -1,7 +1,6 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
 import { fetchTokenPrice } from "../examples/hub-api";
-import { berachain } from "viem/chains";
-import { createPublicClient, http, parseEther } from "viem";
+import { parseEther } from "viem";
 
 export class TermMaxVaultAdapter extends BaseAdapter {
     constructor() {
@@ -33,15 +32,10 @@ export class TermMaxVaultAdapter extends BaseAdapter {
      * These prices are used to calculate TVL for APR calculations
      */
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
                 // ERC4626: Convert 1 share to assets to get the ratio
-                const ratio = await publicClient.readContract({
+                const ratio = await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     args: [parseEther("1")],
                     abi: [
@@ -57,7 +51,7 @@ export class TermMaxVaultAdapter extends BaseAdapter {
                 });
 
                 // Get the underlying asset address
-                const underlyingAsset = await publicClient.readContract({
+                const underlyingAsset = await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {

--- a/src/vaults/wasabi/wasabiVaultAdapter.ts
+++ b/src/vaults/wasabi/wasabiVaultAdapter.ts
@@ -1,7 +1,6 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
 import { fetchTokenPrice } from "../examples/hub-api";
-import { berachain } from "viem/chains";
-import { createPublicClient, http, parseEther } from "viem";
+import { parseEther } from "viem";
 
 export class WasabiVaultAdapter extends BaseAdapter {
     constructor() {
@@ -43,16 +42,10 @@ export class WasabiVaultAdapter extends BaseAdapter {
      * These prices are used to calculate TVL for APR calculations
      */
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        // Create a public client directly in the function
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
                 // Perform individual calls to get the underlying asset, totalSupply and totalAssets
-                const totalSupply = (await publicClient.readContract({
+                const totalSupply = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -66,7 +59,7 @@ export class WasabiVaultAdapter extends BaseAdapter {
                     functionName: "totalSupply",
                 })) as bigint;
 
-                const totalAssets = (await publicClient.readContract({
+                const totalAssets = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -80,7 +73,7 @@ export class WasabiVaultAdapter extends BaseAdapter {
                     functionName: "totalAssets",
                 })) as bigint;
 
-                const underlyingAsset = (await publicClient.readContract({
+                const underlyingAsset = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {

--- a/src/vaults/webera/weiberaVaultAdapter.ts
+++ b/src/vaults/webera/weiberaVaultAdapter.ts
@@ -1,6 +1,4 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
 
 export class WeiberaVaultAdapter extends BaseAdapter {
     constructor() {
@@ -33,14 +31,9 @@ export class WeiberaVaultAdapter extends BaseAdapter {
      * These prices are used to calculate TVL for APR calculations
      */
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
-                const totalSupply = (await publicClient.readContract({
+                const totalSupply = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -54,7 +47,7 @@ export class WeiberaVaultAdapter extends BaseAdapter {
                     functionName: "totalSupply",
                 })) as bigint;
 
-                const totalAssets = (await publicClient.readContract({
+                const totalAssets = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {

--- a/src/vaults/webera/wewberaVaultAdapter.ts
+++ b/src/vaults/webera/wewberaVaultAdapter.ts
@@ -1,6 +1,4 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
 
 export class WewberaVaultAdapter extends BaseAdapter {
     constructor() {
@@ -33,14 +31,9 @@ export class WewberaVaultAdapter extends BaseAdapter {
      * These prices are used to calculate TVL for APR calculations
      */
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
-                const totalSupply = (await publicClient.readContract({
+                const totalSupply = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {
@@ -54,7 +47,7 @@ export class WewberaVaultAdapter extends BaseAdapter {
                     functionName: "totalSupply",
                 })) as bigint;
 
-                const totalAssets = (await publicClient.readContract({
+                const totalAssets = (await this.publicClient.readContract({
                     address: token.address as `0x${string}`,
                     abi: [
                         {

--- a/src/vaults/winnieswap/WinnieSwapAdapter.ts
+++ b/src/vaults/winnieswap/WinnieSwapAdapter.ts
@@ -1,6 +1,4 @@
 import { BaseAdapter, Token, TokenPrice } from "../../types";
-import { berachain } from "viem/chains";
-import { createPublicClient, http } from "viem";
 
 // GraphQL endpoint for WinnieSwap Indexer (Ponder)
 const WINNIESWAP_GRAPHQL_URL = "https://sub.winnieswap.com/";
@@ -116,16 +114,11 @@ export class WinnieSwapAdapter extends BaseAdapter {
      * Price = (totalAmount0 * price0 + totalAmount1 * price1) / totalSupply
      */
     async getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]> {
-        const publicClient = createPublicClient({
-            chain: berachain,
-            transport: http("https://rpc.berachain.com"),
-        });
-
         const prices = await Promise.all(
             stakingTokens.map(async (token) => {
                 try {
                     // Get total supply of the vault token
-                    const totalSupply = (await publicClient.readContract({
+                    const totalSupply = (await this.publicClient.readContract({
                         address: token.address as `0x${string}`,
                         abi: [
                             {
@@ -152,7 +145,7 @@ export class WinnieSwapAdapter extends BaseAdapter {
                     }
 
                     // Get underlying balances (amount0, amount1)
-                    const [totalAmount0, totalAmount1] = (await publicClient.readContract({
+                    const [totalAmount0, totalAmount1] = (await this.publicClient.readContract({
                         address: token.address as `0x${string}`,
                         abi: [
                             {
@@ -178,7 +171,7 @@ export class WinnieSwapAdapter extends BaseAdapter {
                     })) as [bigint, bigint];
 
                     // Get token0 and token1 addresses
-                    const token0_addr = (await publicClient.readContract({
+                    const token0_addr = (await this.publicClient.readContract({
                         address: token.address as `0x${string}`,
                         abi: [
                             {
@@ -192,7 +185,7 @@ export class WinnieSwapAdapter extends BaseAdapter {
                         functionName: "token0",
                     })) as string;
 
-                    const token1_addr = (await publicClient.readContract({
+                    const token1_addr = (await this.publicClient.readContract({
                         address: token.address as `0x${string}`,
                         abi: [
                             {


### PR DESCRIPTION
Providing a way to customize publicClient, so that we can use private RPCs on the bex api.

Also adds a check to make sure all adapters are exported.