### PR TITLE
ci: pin GitHub Actions to full commit SHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,9 +11,9 @@ jobs:
         runs-on: ubuntu-latest
         name: build
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
             - name: Setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: latest
             - name: Install dependencies

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -11,9 +11,9 @@ jobs:
         runs-on: ubuntu-latest
         name: Prettier
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
             - name: Setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: latest
             - name: Install dev dependencies

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,9 +11,9 @@ jobs:
         runs-on: ubuntu-latest
         name: ESLint
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
             - name: Setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: latest
             - name: Install dev dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,18 +12,18 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/create-github-app-token@v1
+            - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
               id: app-token
               with:
                   app-id: ${{ vars.BOT_APP_ID }}
                   private-key: ${{ secrets.BOT_KEY }}
             - name: Checkout repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
               with:
                   ref: ${{ github.event.repository.default_branch }}
                   token: ${{ steps.app-token.outputs.token }}
             - name: Setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: latest
                   registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
SHA-pin all actions. Mutable tags can be force-pushed if an action repo is compromised, and evaporate if it is disabled (cf. Azure/functions-action, Jun 5 Miasma). Stopgap ahead of Renovate digest maintenance. Ref: Miasma scan 2026-06-09.