### PR TITLE
chore: remove incentive tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,27 +130,6 @@ export class YourProtocolAdapter extends BaseAdapter {
             },
         ];
     }
-
-    /**
-     * Get incentive/reward tokens
-     * These tokens are used to calculate reward value for APR calculations
-     */
-    async getIncentiveTokens(): Promise<Token[]> {
-        // Implement to return incentive tokens
-        return [];
-    }
-
-    /**
-     * Get prices for incentive tokens
-     * These prices are used to calculate reward value for APR calculations
-     *
-     * Note: You don't need to implement this if your token is already listed on Hub or Kodiak,
-     * or if it's tracked by Coingecko (in which case, add it to the Berachain Metadata repo)
-     */
-    async getIncentiveTokenPrices(incentiveTokens: Token[]): Promise<TokenPrice[]> {
-        // Implement to return incentive token prices
-        return [];
-    }
 }
 ```
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,21 +70,7 @@ export abstract class BaseAdapter {
      * @returns Promise resolving to list of token prices
      */
     abstract getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]>;
-
-    /**
-     * Get incentive/reward tokens available in the protocol
-     * @returns Promise resolving to list of tokens
-     */
-    abstract getIncentiveTokens(): Promise<Token[]>;
-
-    /**
-     * Get prices for incentive tokens. These prices will be used to determine total usd value of incentives as well as BGT APRs
-     * DO NOT include staking tokens in this list
-     * NO NEED to include incentive tokens that already have prices on https://hub.berachain.com/vaults
-     * @returns Promise resolving to list of token prices
-     */
-    abstract getIncentiveTokenPrices(incentiveTokens: Token[]): Promise<TokenPrice[]>;
-
+  
     TOKEN_PRICE_QUERY = gql`
         query ($tokens: [String!]!) {
             tokenGetCurrentPrices(chains: [BERACHAIN], addressIn: $tokens) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,7 +70,7 @@ export abstract class BaseAdapter {
      * @returns Promise resolving to list of token prices
      */
     abstract getRewardVaultStakingTokenPrices(stakingTokens: Token[]): Promise<TokenPrice[]>;
-  
+
     TOKEN_PRICE_QUERY = gql`
         query ($tokens: [String!]!) {
             tokenGetCurrentPrices(chains: [BERACHAIN], addressIn: $tokens) {

--- a/src/utils/adapter.test.ts
+++ b/src/utils/adapter.test.ts
@@ -106,7 +106,7 @@ async function run(adapters: (typeof BaseAdapter)[]) {
                 const token = tokens.find((t: Token) => t.address === price.address);
                 console.log(`  ${token?.symbol}: $${price.price}`);
             }
-        } 
+        }
     }
     console.log("\n" + "=".repeat(50) + "\n");
 }

--- a/src/utils/adapter.test.ts
+++ b/src/utils/adapter.test.ts
@@ -106,20 +106,7 @@ async function run(adapters: (typeof BaseAdapter)[]) {
                 const token = tokens.find((t: Token) => t.address === price.address);
                 console.log(`  ${token?.symbol}: $${price.price}`);
             }
-        }
-
-        // Get incentive tokens and their prices
-        const incentiveTokens = await adapter.getIncentiveTokens();
-        const incentivePrices = await adapter.getIncentiveTokenPrices(incentiveTokens);
-
-        if (incentivePrices.length > 0) {
-            console.log("\nIncentive Tokens:");
-            console.log("-".repeat(30));
-            for (const price of incentivePrices) {
-                const token = incentiveTokens.find((t: Token) => t.address === price.address);
-                console.log(`  ${token?.symbol}: $${price.price}`);
-            }
-        }
+        } 
     }
     console.log("\n" + "=".repeat(50) + "\n");
 }

--- a/src/vaults/aquabera/AquaBeraAdapter.ts
+++ b/src/vaults/aquabera/AquaBeraAdapter.ts
@@ -142,40 +142,5 @@ export class AquaBeraAdapter extends BaseAdapter {
             }
         );
     }
-
-    /**
-     * Get incentive/reward tokens
-     * These tokens are used to calculate reward value for APR calculations
-     */
-    async getIncentiveTokens(): Promise<Token[]> {
-        // Implement to return incentive tokens
-        return [
-            {
-                address: "0xb2F776e9c1C926C4b2e54182Fac058dA9Af0B6A5",
-                symbol: "HENLO",
-                name: "Henlo Token",
-                decimals: 18,
-                chainId: 80094,
-            },
-            {
-                address: "0x6969696969696969696969696969696969696969",
-                symbol: "WBERA",
-                name: "Wrapped Bera",
-                decimals: 18,
-                chainId: 80094,
-            },
-        ];
-    }
-
-    /**
-     * Get prices for incentive tokens
-     * These prices are used to calculate reward value for APR calculations
-     *
-     * Note: You don't need to implement this if your token is already listed on Hub or Kodiak,
-     * or if it's tracked by Coingecko (in which case, add it to the Berachain Metadata repo)
-     */
-    async getIncentiveTokenPrices(): Promise<TokenPrice[]> {
-        // Implement to return incentive token prices
-        return [];
-    }
+ 
 }

--- a/src/vaults/aquabera/AquaBeraAdapter.ts
+++ b/src/vaults/aquabera/AquaBeraAdapter.ts
@@ -142,5 +142,4 @@ export class AquaBeraAdapter extends BaseAdapter {
             }
         );
     }
- 
 }

--- a/src/vaults/brownfi/BrownFiVaultAdapter.ts
+++ b/src/vaults/brownfi/BrownFiVaultAdapter.ts
@@ -145,5 +145,5 @@ export class BrownFiVaultAdapter extends BaseAdapter {
                 };
             }
         );
-    } 
+    }
 }

--- a/src/vaults/brownfi/BrownFiVaultAdapter.ts
+++ b/src/vaults/brownfi/BrownFiVaultAdapter.ts
@@ -145,28 +145,5 @@ export class BrownFiVaultAdapter extends BaseAdapter {
                 };
             }
         );
-    }
-
-    async getIncentiveTokens(): Promise<Token[]> {
-        return [
-            {
-                address: "0x549943e04f40284185054145c6E4e9568C1D3241",
-                name: "Bridged USDC (Stargate) (USDC.e)",
-                symbol: "USDC.e",
-                decimals: 18,
-                chainId: 80094,
-            },
-            {
-                address: "0x6969696969696969696969696969696969696969",
-                symbol: "WBERA",
-                name: "Wrapped BERA",
-                decimals: 18,
-                chainId: 80094,
-            },
-        ];
-    }
-
-    async getIncentiveTokenPrices(_incentiveTokens: Token[]): Promise<TokenPrice[]> {
-        return [];
-    }
+    } 
 }

--- a/src/vaults/bullish/BullIshGaugeAdapter.ts
+++ b/src/vaults/bullish/BullIshGaugeAdapter.ts
@@ -58,5 +58,4 @@ export class BullIshGaugeAdapter extends BaseAdapter {
 
         return prices;
     }
- 
 }

--- a/src/vaults/bullish/BullIshGaugeAdapter.ts
+++ b/src/vaults/bullish/BullIshGaugeAdapter.ts
@@ -58,34 +58,5 @@ export class BullIshGaugeAdapter extends BaseAdapter {
 
         return prices;
     }
-
-    async getIncentiveTokens(): Promise<Token[]> {
-        return [
-            {
-                address: "0x9b6761bf2397Bb5a6624a856cC84A3A14Dcd3fe5",
-                symbol: "iBERA",
-                name: "Infrared Bera",
-                decimals: 18,
-                chainId: 80094,
-            },
-            {
-                address: "0xD77552D3849ab4D8C3b189A9582d0ba4C1F4f912",
-                symbol: "wgBERA",
-                name: "Wrapped gBERA",
-                decimals: 18,
-                chainId: 80094,
-            },
-            {
-                address: "0x6969696969696969696969696969696969696969",
-                symbol: "WBERA",
-                name: "Wrapped BERA",
-                decimals: 18,
-                chainId: 80094,
-            },
-        ];
-    }
-
-    async getIncentiveTokenPrices(): Promise<TokenPrice[]> {
-        return [];
-    }
+ 
 }

--- a/src/vaults/concrete/concreteVaultsAdapter.ts
+++ b/src/vaults/concrete/concreteVaultsAdapter.ts
@@ -337,13 +337,5 @@ export class ConcreteVaultAdapter extends BaseAdapter {
             })
         );
     }
-
-    async getIncentiveTokens(): Promise<Token[]> {
-        return concreteVaults.map((v) => v.incentiveToken);
-    }
-
-    async getIncentiveTokenPrices(_incentiveTokens: Token[]): Promise<TokenPrice[]> {
-        // Not implemented (per original pattern)
-        return [];
-    }
+ 
 }

--- a/src/vaults/concrete/concreteVaultsAdapter.ts
+++ b/src/vaults/concrete/concreteVaultsAdapter.ts
@@ -3,7 +3,6 @@ import { BaseAdapter, Token, TokenPrice } from "../../types";
 interface ConcreteVault {
     vaultAddress: `0x${string}`;
     stakingToken: Token;
-    incentiveToken: Token;
     funded: boolean;
 }
 
@@ -18,13 +17,6 @@ const concreteVaults: Array<ConcreteVault> = [
             decimals: 18,
             chainId: 80094,
         },
-        incentiveToken: {
-            address: "0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce",
-            name: "Honey (HONEY)",
-            symbol: "HONEY",
-            decimals: 18,
-            chainId: 80094,
-        },
         funded: true,
     },
     {
@@ -33,13 +25,6 @@ const concreteVaults: Array<ConcreteVault> = [
             address: "0x6e0a95f6ac86ead002d58c83fc1b5a712ee9be7c",
             name: "Concrete Berabaddies BERA Vault Token",
             symbol: "ctBeraBaddiesWBERA",
-            decimals: 18,
-            chainId: 80094,
-        },
-        incentiveToken: {
-            address: "0x6969696969696969696969696969696969696969",
-            name: "Wrapped Bera (WBERA)",
-            symbol: "WBERA",
             decimals: 18,
             chainId: 80094,
         },
@@ -54,13 +39,6 @@ const concreteVaults: Array<ConcreteVault> = [
             decimals: 18,
             chainId: 80094,
         },
-        incentiveToken: {
-            address: "0x6fc6545d5cDE268D5C7f1e476D444F39c995120d",
-            name: "Berachain Staked ETH (beraETH)",
-            symbol: "beraETH",
-            decimals: 18,
-            chainId: 80094,
-        },
         funded: false,
     },
     {
@@ -72,13 +50,7 @@ const concreteVaults: Array<ConcreteVault> = [
             decimals: 18,
             chainId: 80094,
         },
-        incentiveToken: {
-            address: "0xbAC93A69c62a1518136FF840B788Ba715cbDfE2B",
-            name: "Fire Bitcoin (FBTC)",
-            symbol: "FBTC",
-            decimals: 18,
-            chainId: 80094,
-        },
+
         funded: false,
     },
     {
@@ -90,13 +62,7 @@ const concreteVaults: Array<ConcreteVault> = [
             decimals: 18,
             chainId: 80094,
         },
-        incentiveToken: {
-            address: "0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce",
-            name: "Honey (HONEY)",
-            symbol: "HONEY",
-            decimals: 18,
-            chainId: 80094,
-        },
+
         funded: false,
     },
     {
@@ -105,13 +71,6 @@ const concreteVaults: Array<ConcreteVault> = [
             address: "0x894d3d9d4542a307a3c76c82695bf5581fcc1383",
             name: "Concrete Berachain LBTC Vault Token",
             symbol: "ctBeraLBTC",
-            decimals: 18,
-            chainId: 80094,
-        },
-        incentiveToken: {
-            address: "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
-            name: "Lombard Staked BTC (LBTC)",
-            symbol: "LBTC",
             decimals: 18,
             chainId: 80094,
         },
@@ -126,13 +85,6 @@ const concreteVaults: Array<ConcreteVault> = [
             decimals: 18,
             chainId: 80094,
         },
-        incentiveToken: {
-            address: "0x549943e04f40284185054145c6E4e9568C1D3241",
-            name: "Bridged USDC (Stargate) (USDC.e)",
-            symbol: "USDC.e",
-            decimals: 18,
-            chainId: 80094,
-        },
         funded: false,
     },
     {
@@ -141,13 +93,6 @@ const concreteVaults: Array<ConcreteVault> = [
             address: "0x52fe4126d6991d1095369dfe1a8ca17fd1aa401b",
             name: "Concrete Berachain USDT0 Vault Token",
             symbol: "ctBeraUSDT0",
-            decimals: 18,
-            chainId: 80094,
-        },
-        incentiveToken: {
-            address: "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
-            name: "USD₮0 (USD₮0)",
-            symbol: "USDT0",
             decimals: 18,
             chainId: 80094,
         },
@@ -162,13 +107,6 @@ const concreteVaults: Array<ConcreteVault> = [
             decimals: 18,
             chainId: 80094,
         },
-        incentiveToken: {
-            address: "0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34",
-            name: "USDe (USDe)",
-            symbol: "USDe",
-            decimals: 18,
-            chainId: 80094,
-        },
         funded: false,
     },
     {
@@ -177,13 +115,6 @@ const concreteVaults: Array<ConcreteVault> = [
             address: "0xea31ae7f4b4205badba164b1469e8f71de9ea867",
             name: "Concrete Berachain BERA Vault Token",
             symbol: "ctBeraWBERA",
-            decimals: 18,
-            chainId: 80094,
-        },
-        incentiveToken: {
-            address: "0x6969696969696969696969696969696969696969",
-            name: "Wrapped Bera (WBERA)",
-            symbol: "WBERA",
             decimals: 18,
             chainId: 80094,
         },
@@ -198,13 +129,6 @@ const concreteVaults: Array<ConcreteVault> = [
             decimals: 18,
             chainId: 80094,
         },
-        incentiveToken: {
-            address: "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
-            name: "Wrapped BTC (WBTC)",
-            symbol: "WBTC",
-            decimals: 18,
-            chainId: 80094,
-        },
         funded: false,
     },
     {
@@ -213,13 +137,6 @@ const concreteVaults: Array<ConcreteVault> = [
             address: "0xffb155ef53cb08a0722c9eeeea5cb362d77ba125",
             name: "Concrete Berachain sUSDe Vault Token",
             symbol: "ctBerasUSDe",
-            decimals: 18,
-            chainId: 80094,
-        },
-        incentiveToken: {
-            address: "0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2",
-            name: "Staked USDe (sUSDe)",
-            symbol: "sUSDe",
             decimals: 18,
             chainId: 80094,
         },
@@ -234,13 +151,6 @@ const concreteVaults: Array<ConcreteVault> = [
             decimals: 18,
             chainId: 80094,
         },
-        incentiveToken: {
-            address: "0xC3827A4BC8224ee2D116637023b124CED6db6e90",
-            name: "uniBTC (uniBTC)",
-            symbol: "uniBTC",
-            decimals: 18,
-            chainId: 80094,
-        },
         funded: false,
     },
     {
@@ -249,13 +159,6 @@ const concreteVaults: Array<ConcreteVault> = [
             address: "0x238cb854d644cb9b7a08e65eb803bffc05cfb834",
             name: "Concrete Berachain WETH Vault Token",
             symbol: "ctBeraWETH",
-            decimals: 18,
-            chainId: 80094,
-        },
-        incentiveToken: {
-            address: "0x2f6f07cdcf3588944bf4c42ac74ff24bf56e7590",
-            name: "WETH (WETH)",
-            symbol: "WETH",
             decimals: 18,
             chainId: 80094,
         },
@@ -337,5 +240,4 @@ export class ConcreteVaultAdapter extends BaseAdapter {
             })
         );
     }
- 
 }

--- a/src/vaults/ivx/ivx-adapter.ts
+++ b/src/vaults/ivx/ivx-adapter.ts
@@ -131,39 +131,5 @@ export class IVXVaultAdapter extends BaseAdapter {
                     }) as const
             ),
         });
-    }
-    /**
-     * Get incentive/reward tokens
-     * These tokens are used to calculate reward value for APR calculations
-     */
-    async getIncentiveTokens(): Promise<Token[]> {
-        return [
-            {
-                address: "0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce",
-                symbol: "HONEY",
-                name: "Honey",
-                decimals: 18,
-                chainId: 80094,
-            },
-            {
-                address: "0x6969696969696969696969696969696969696969",
-                symbol: "WBERA",
-                name: "Wrapped Bera",
-                decimals: 18,
-                chainId: 80094,
-            },
-        ];
-    }
-
-    /**
-     * Get prices for incentive tokens
-     * These prices are used to calculate reward value for APR calculations
-     *
-     * Note: You don't need to implement this if your token is already listed on Hub or Kodiak,
-     * or if it's tracked by Coingecko (in which case, add it to the Berachain Metadata repo)
-     */
-    async getIncentiveTokenPrices(_incentiveTokens: Token[]): Promise<TokenPrice[]> {
-        // Implement to return incentive token prices
-        return [];
-    }
+    } 
 }

--- a/src/vaults/ivx/ivx-adapter.ts
+++ b/src/vaults/ivx/ivx-adapter.ts
@@ -131,5 +131,5 @@ export class IVXVaultAdapter extends BaseAdapter {
                     }) as const
             ),
         });
-    } 
+    }
 }

--- a/src/vaults/solv/SolvBTCBeraVaultAdapter.ts
+++ b/src/vaults/solv/SolvBTCBeraVaultAdapter.ts
@@ -45,47 +45,4 @@ export class SolvBTCBeraVaultAdapter extends BaseAdapter {
         );
         return prices;
     }
-
-    /**
-     * Get incentive/reward tokens
-     * These tokens are used to calculate reward value for APR calculations
-     */
-    async getIncentiveTokens(): Promise<Token[]> {
-        // Implement to return incentive tokens
-        return [
-            {
-                address: "0x541FD749419CA806a8bc7da8ac23D346f2dF8B77",
-                name: "Solv BTC",
-                symbol: "SolvBTC",
-                decimals: 18,
-                chainId: 80094,
-            },
-            {
-                address: "0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce",
-                name: "Honey",
-                symbol: "HONEY",
-                decimals: 18,
-                chainId: 80094,
-            },
-            {
-                address: "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
-                name: "Infrared BGT",
-                symbol: "iBGT",
-                decimals: 18,
-                chainId: 80094,
-            },
-        ];
-    }
-
-    /**
-     * Get prices for incentive tokens
-     * These prices are used to calculate reward value for APR calculations
-     *
-     * Note: You don't need to implement this if your token is already listed on Hub or Kodiak,
-     * or if it's tracked by Coingecko (in which case, add it to the Berachain Metadata repo)
-     */
-    async getIncentiveTokenPrices(_incentiveTokens: Token[]): Promise<TokenPrice[]> {
-        // Implement to return incentive token prices
-        return [];
-    }
 }

--- a/src/vaults/sx/sxVaultAdapter.ts
+++ b/src/vaults/sx/sxVaultAdapter.ts
@@ -43,33 +43,4 @@ export class SxVaultAdapter extends BaseAdapter {
         );
         return prices;
     }
-
-    /**
-     * Get incentive/reward tokens
-     * These tokens are used to calculate reward value for APR calculations
-     */
-    async getIncentiveTokens(): Promise<Token[]> {
-        // Implement to return incentive tokens
-        return [
-            {
-                address: "0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce",
-                name: "Honey",
-                symbol: "HONEY",
-                decimals: 18,
-                chainId: 80094,
-            },
-        ];
-    }
-
-    /**
-     * Get prices for incentive tokens
-     * These prices are used to calculate reward value for APR calculations
-     *
-     * Note: You don't need to implement this if your token is already listed on Hub or Kodiak,
-     * or if it's tracked by Coingecko (in which case, add it to the Berachain Metadata repo)
-     */
-    async getIncentiveTokenPrices(_incentiveTokens: Token[]): Promise<TokenPrice[]> {
-        // Implement to return incentive token prices
-        return [];
-    }
 }


### PR DESCRIPTION
## What

Removes the `getIncentiveTokens` / `getIncentiveTokenPrices` API from the adapter framework and all adapters that implemented it.

## Why

Incentive tokens are no longer used for APR calculations, so the methods were dead weight — most implementations just returned a hardcoded token list with an empty price array anyway.

## How

- Drop both abstract methods from `BaseAdapter` (`src/types/index.ts`)
- Remove the implementations from all 7 adapters (aquabera, brownfi, bullish, concrete, ivx, solv, sx)
- Strip the incentive token section from the test harness (`adapter.test.ts`) and the README template